### PR TITLE
use full package name in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This package has several utilities and configurations that can be used in your p
 #### Jest Config
 [This configuration](./src/jestConfig.js) pulls in several setup scripts as well as enabling screenshots and slack reporting. The easiest way is to create a `jest.config.js` file in the root of your project or putting it somewhere else and using the Jest param `--config path\to\config\file`. To pull in the Jest config from this package, put the code below in `jest.config.js`.
 ```javascript
-const { jestConfig } = require( 'puppeteer-utils' );
+const { jestConfig } = require( '@automattic/puppeteer-utils' );
 
 module.exports = jestConfig;
 ```
@@ -22,14 +22,14 @@ There are two options for the Jest Puppeteer config.
 
 **Option 1:** Use the Jest Puppeteer config as is from this package. The `useJestPuppeteerConfig` method sets the `JEST_PUPPETEER_CONFIG` environment variable to point to the config file within the package. A good place to use this is in the `jest.config.js` file created above.
 ```javascript
-const { useJestPuppeteerConfig } = require( 'puppeteer-utils' );
+const { useJestPuppeteerConfig } = require( '@automattic/puppeteer-utils' );
 
 useJestPuppeteerConfig();
 ```
 
 **Option 2:** Create your own `jest-puppeteer.config.js` file and set the `JEST_PUPPETEER_CONFIG` to point to your file. You can use the config from this package as a base, or as it is.
 ```javascript
-const { jestPuppeteerConfig } = require( 'puppeteer-utils' );
+const { jestPuppeteerConfig } = require( '@automattic/puppeteer-utils' );
 
 module.exports = jestPuppeteerConfig;
 ```
@@ -38,7 +38,7 @@ module.exports = jestPuppeteerConfig;
 #### Overwriting or extending Jest Config or Jest Puppeteer Config
 If you need to add config values, scripts or overwrite values, you can do so. Here is an example of adding a new setup script.
 ```javascript
-const { jestConfig } = require( 'puppeteer-utils' );
+const { jestConfig } = require( '@automattic/puppeteer-utils' );
 
 // Save current config
 const jestConfigMod = jestConfig;
@@ -59,7 +59,7 @@ module.exports = jestConfigMod;
 #### Page Utilities
 The Page object offers several functions that extend existing puppeteer functionality. 
 ```javascript
-import { waitAndType, waitAndClick } from 'puppeteer-utils';
+import { waitAndType, waitAndClick } from '@automattic/puppeteer-utils';
 
 const titleSelector = '.my-title';
 const title = 'My Test Title';


### PR DESCRIPTION
This is a quick PR to update the package in the readme examples to `@automattic/puppeteer-utils`.